### PR TITLE
use ffmpeg for video duration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "videohash"
-version = "7.0.0"
+version = "8.0.0"
 authors = ["gfield <github@gfield.de>", "Akash Mahanty <akamhy@yahoo.com>"]
 description = "Near Duplicate Video Detection (Perceptual Video Hashing) - Get a 256-bit comparable hash-value for any video. "
 license = "MIT"

--- a/tests/test_videoduration.py
+++ b/tests/test_videoduration.py
@@ -15,4 +15,4 @@ def videofile():
 @pytest.mark.gold
 @pytest.mark.integration
 def test_video_duration(videofile):
-    assert (video_duration(videofile) - 52.08) < 0.1
+    assert (video_duration(videofile, "ffmpeg") - 52.08) < 0.001

--- a/tests/test_videohash.py
+++ b/tests/test_videohash.py
@@ -26,7 +26,7 @@ def test_videohash_videohash(videofile: Path):
     assert (
         vhobj.hex == "b052b1537b5a0cf0d8a4da8686872b242fa5f8456d472dcd705f521f862f0fbd"
     )
-    assert vhobj.duration == 52.079
+    assert vhobj.duration == 52.08
 
 
 @pytest.mark.gold
@@ -36,7 +36,7 @@ def test_videohash_phash(videofile: Path):
     # fmt:off
     assert np.array_equal(ph, np.array([True,False,True,True,False,False,False,False,False,True,False,True,False,False,True,False,True,False,True,True,False,False,False,True,False,True,False,True,False,False,True,True,False,True,True,True,True,False,True,True,False,True,False,True,True,False,True,False,False,False,False,False,True,True,False,False,True,True,True,True,False,False,False,False,True,True,False,True,True,False,False,False,True,False,True,False,False,True,False,False,True,True,False,True,True,False,True,False,True,False,False,False,False,True,True,False,True,False,False,False,False,True,True,False,True,False,False,False,False,True,True,True,False,False,True,False,True,False,True,True,False,False,True,False,False,True,False,False,False,False,True,False,True,True,True,True,True,False,True,False,False,True,False,True,True,True,True,True,True,False,False,False,False,True,False,False,False,True,False,True,False,True,True,False,True,True,False,True,False,True,False,False,False,True,True,True,False,False,True,False,True,True,False,True,True,True,False,False,True,True,False,True,False,True,True,True,False,False,False,False,False,True,False,True,True,True,True,True,False,True,False,True,False,False,True,False,False,False,False,True,True,True,True,True,True,False,False,False,False,True,True,False,False,False,True,False,True,True,True,True,False,False,False,False,True,True,True,True,True,False,True,True,True,True,False,True]))
 
-    assert dur == 52.079
+    assert dur == 52.08
     # fmt:on
 
 
@@ -45,7 +45,7 @@ def test_videohash_phash(videofile: Path):
 def test_videohash_phex(videofile: Path):
     ph, dur = phex(videofile)
     assert ph == "b052b1537b5a0cf0d8a4da8686872b242fa5f8456d472dcd705f521f862f0fbd"
-    assert dur == 52.079
+    assert dur == 52.08
 
 
 @pytest.mark.gold

--- a/videohash/__init__.py
+++ b/videohash/__init__.py
@@ -23,8 +23,6 @@ from .exceptions import (
     FFmpegNotFound,
     VideoHashError,
     VideoHashNoDuration,
-    FFprobeError,
-    FFprobeNoVideoDurationSpecified,
-    FFprobeVideoDurationReadError,
+    FFmpegVideoDurationReadError,
 )
 from .videohash import VideoHash, phash, phex

--- a/videohash/collage.py
+++ b/videohash/collage.py
@@ -36,8 +36,6 @@ def make_collage(
         # paste the frame image onto base image
         collage_image.paste(frame, (x, y))
 
-        frame.close()
-
         # get the x coordinate of the next frame
         x += frame_size
 

--- a/videohash/exceptions.py
+++ b/videohash/exceptions.py
@@ -41,19 +41,7 @@ class FFmpegFailedToExtractFrames(FFmpegError):
     pass
 
 
-class FFprobeError(VideoHashError):
-    """Base error for ffprobe exceptions."""
-
-    pass
-
-
-class FFprobeVideoDurationReadError(FFprobeError):
-    """FFprobe failed to get duration from video file."""
-
-    pass
-
-
-class FFprobeNoVideoDurationSpecified(FFprobeError):
-    """First video stream does not have a specified duration."""
+class FFmpegVideoDurationReadError(FFmpegError):
+    """FFmpeg failed to get duration from video file."""
 
     pass

--- a/videohash/extract.py
+++ b/videohash/extract.py
@@ -12,7 +12,7 @@ from .utils import runn
 def _detect_crop(
     video_path: Path,
     duration: float,
-    ffmpeg_path: str,
+    ffmpeg_path: Path | str,
     samples: int = 4,
     samplesize: int = 2,
 ):
@@ -34,14 +34,15 @@ def _detect_crop(
     for ts in timestamps:
         commands.append(
             [
-                ffmpeg_path,
+                f"{ffmpeg_path}",
                 "-v",
                 "32",
+                "-hide_banner",
                 "-ss",
                 f"{ts}",
                 "-i",
                 f"{video_path}",
-                "-vframes",
+                "-frames:v",
                 f"{samplesize}",
                 "-vf",
                 "cropdetect",
@@ -74,7 +75,7 @@ def extract_frames(
     frame_count: int,
     frame_size: int,
     ffmpeg_threads: int,
-    ffmpeg_path: str,
+    ffmpeg_path: Path | str,
 ) -> list[Image.Image]:
     crop = _detect_crop(
         video_path=video_path,

--- a/videohash/videohash.py
+++ b/videohash/videohash.py
@@ -8,7 +8,7 @@ import numpy as np
 from .exceptions import (
     FFmpegError,
     FFmpegNotFound,
-    FFprobeError,
+    FFmpegVideoDurationReadError,
     VideoHashNoDuration,
 )
 from .extract import extract_frames
@@ -48,14 +48,14 @@ class VideoHash:
         if not video_path.is_file():
             raise FileNotFoundError(f"No video found at '{self.video_path}'")
 
+        ffmpeg_path = _check_ffmpeg(ffmpeg_path=ffmpeg_path)
+
         try:
-            self.duration = video_duration(self.video_path)
-        except FFprobeError as e:
+            self.duration = video_duration(self.video_path, ffmpeg_path)
+        except FFmpegVideoDurationReadError as e:
             raise VideoHashNoDuration(
                 f"Failed to get video duration using ffprobe. Cannot generate phash without duration."
             ) from e
-
-        ffmpeg_path = _check_ffmpeg(ffmpeg_path=ffmpeg_path)
 
         self._frame_count = frame_count
         self._frame_size = frame_size

--- a/videohash/videohash.py
+++ b/videohash/videohash.py
@@ -73,6 +73,8 @@ class VideoHash:
             image_list=frames,
             frame_size=self._frame_size,
         )
+        for f in frames:
+            f.close()
 
         self._calc_hash()
         self._collage.close()

--- a/videohash/videohash.py
+++ b/videohash/videohash.py
@@ -76,7 +76,7 @@ class VideoHash:
         for f in frames:
             f.close()
 
-        self._calc_hash()
+        self.hash, self.hex = _calc_hash(self._collage, self.hashlength)
         self._collage.close()
 
     def __str__(self) -> str:
@@ -101,26 +101,28 @@ class VideoHash:
         """
         return len(self.hash)
 
-    def _calc_hash(self) -> None:
-        """
-        Calculate the hash value by calling the phash (perceptual hash) method of ImageHash package. The perceptual hash of the collage is the VideoHash for the original input video.
-        """
-        ih = imagehash.phash(self._collage, hash_size=isqrt(self.hashlength))
 
-        self.hash: np.ndarray = ih.hash.flatten()
-        self.hex: str = f"{ih}"
+def _calc_hash(img, hashlen: int) -> tuple[np.ndarray, str]:
+    """
+    Calculate the hash value by calling the phash (perceptual hash) method of ImageHash package. The perceptual hash of the collage is the VideoHash for the original input video.
+    """
+    ih = imagehash.phash(img, hash_size=isqrt(hashlen))
+
+    hash: np.ndarray = ih.hash.flatten()
+    hex: str = f"{ih}"
+    return hash, hex
 
 
-def _check_ffmpeg(ffmpeg_path: Path | str) -> str:
+def _check_ffmpeg(ffmpeg_path: Path | str) -> Path | str:
     """
     Check the FFmpeg path and run 'ffmpeg -version' to verify that FFmpeg is found and works.
     """
     if isinstance(ffmpeg_path, Path):
-        ffmpeg_path = ffmpeg_path.resolve().as_posix()
+        ffmpeg_path = ffmpeg_path.resolve()
 
     try:
         succ, outs = runn(
-            [[ffmpeg_path, "-version"]],
+            [[f"{ffmpeg_path}", "-version"]],
             n=1,
             getout=True,
             geterr=True,


### PR DESCRIPTION
About three times faster.  (up to 8 times with some formats/files)
No more ffprobe dependency.

Only outputs the container duration, not the more desirable and robust first video stream duration, but that's worth the 10-20% overall speed increase.
It is also less precise (rounded to tenth of second) but that should be fine.