### PR TITLE
allow for some frame extractions to fail

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "videohash"
-version = "8.0.4"
+version = "8.1.0"
 authors = ["gfield <github@gfield.de>", "Akash Mahanty <akamhy@yahoo.com>"]
 description = "Near Duplicate Video Detection (Perceptual Video Hashing) - Get a 256-bit comparable hash-value for any video. "
 license = "MIT"

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -1,0 +1,47 @@
+import pytest
+
+from pathlib import Path
+
+from videohash.extract import extract_frames
+from videohash import FFmpegFailedToExtractFrames
+
+
+@pytest.mark.gold
+def test_extract_singleerror_allow():
+    extract_frames(
+        video_path=Path("./tests/gold/rocket/video.mkv"),
+        duration=57.0,  # too long, to make last frame fail
+        frame_count=16,
+        frame_size=240,
+        maxerrors=1,
+        ffmpeg_threads=4,
+        ffmpeg_path="ffmpeg",
+    )
+
+
+@pytest.mark.gold
+def test_extract_singleerror_error():
+    with pytest.raises(FFmpegFailedToExtractFrames):
+        extract_frames(
+            video_path=Path("./tests/gold/rocket/video.mkv"),
+            duration=57.0,  # too long, to make last frame fail
+            frame_count=16,
+            frame_size=240,
+            maxerrors=0,
+            ffmpeg_threads=4,
+            ffmpeg_path="ffmpeg",
+        )
+
+
+@pytest.mark.gold
+def test_extract_twoerror_error():
+    with pytest.raises(FFmpegFailedToExtractFrames):
+        extract_frames(
+            video_path=Path("./tests/gold/rocket/video.mkv"),
+            duration=63.0,  # too long, to make last two frames fail
+            frame_count=16,
+            frame_size=240,
+            maxerrors=1,
+            ffmpeg_threads=4,
+            ffmpeg_path="ffmpeg",
+        )

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -18,6 +18,9 @@ def read_samples():
 @pytest.mark.integration
 @pytest.mark.parametrize("sample", read_samples())
 def test_samples_hash(sample):
+    if not Path(sample[0]).exists():
+        pytest.skip(f"Sample file does not exist (anymore): {sample[0]}")
+
     ph, dur = vh.phex(sample[0])
     assert ph == sample[1]
 
@@ -25,5 +28,8 @@ def test_samples_hash(sample):
 @pytest.mark.gold
 @pytest.mark.parametrize("sample", read_samples())
 def test_samples_duration(sample):
+    if not Path(sample[0]).exists():
+        pytest.skip(f"Sample file does not exist (anymore): {sample[0]}")
+
     dur = video_duration(sample[0], "ffmpeg")
     assert dur == float(sample[2])

--- a/tests/test_samples.py
+++ b/tests/test_samples.py
@@ -15,6 +15,16 @@ def read_samples():
 
 
 @pytest.mark.gold
+@pytest.mark.parametrize("sample", read_samples())
+def test_samples_duration(sample):
+    if not Path(sample[0]).exists():
+        pytest.skip(f"Sample file does not exist (anymore): {sample[0]}")
+
+    dur = video_duration(sample[0], "ffmpeg")
+    assert dur == float(sample[2])
+
+
+@pytest.mark.gold
 @pytest.mark.integration
 @pytest.mark.parametrize("sample", read_samples())
 def test_samples_hash(sample):
@@ -23,13 +33,3 @@ def test_samples_hash(sample):
 
     ph, dur = vh.phex(sample[0])
     assert ph == sample[1]
-
-
-@pytest.mark.gold
-@pytest.mark.parametrize("sample", read_samples())
-def test_samples_duration(sample):
-    if not Path(sample[0]).exists():
-        pytest.skip(f"Sample file does not exist (anymore): {sample[0]}")
-
-    dur = video_duration(sample[0], "ffmpeg")
-    assert dur == float(sample[2])

--- a/tests/test_videohash.py
+++ b/tests/test_videohash.py
@@ -79,7 +79,7 @@ def test_videohash_hash_length(videofile, hash_length):
 
     assert len(vh.hash) == hash_length
     assert len(vh) == hash_length
-    assert vh.hashlength == hash_length
+    assert vh._hash_length == hash_length
     assert len(vh.hex) == hash_length // 4
 
 

--- a/videohash/collage.py
+++ b/videohash/collage.py
@@ -1,5 +1,4 @@
 from math import isqrt
-from pathlib import Path
 from typing import Collection
 
 from PIL import Image

--- a/videohash/utils.py
+++ b/videohash/utils.py
@@ -1,22 +1,4 @@
-from pathlib import Path
-import tempfile
 import subprocess
-import uuid
-
-import numpy as np
-
-
-def get_tempdir(basedir: Path = None) -> Path:
-    base: Path = basedir or Path(tempfile.gettempdir())
-    tempdir = base / f"vh-{uuid.uuid4()}"
-    if not tempdir.exists():
-        tempdir.mkdir(parents=True, exist_ok=False)
-
-    return tempdir
-
-
-def get_files_in_dir(directory: Path) -> list[Path]:
-    return sorted([f for f in directory.iterdir() if f.is_file()])
 
 
 def argstostr(args) -> str:
@@ -70,19 +52,3 @@ def runn(
                     succ = False
 
     return succ, outputs
-
-
-def hex_to_bitstr(s: str) -> str:
-    l = len(s) * 4
-    return format(int(s, 16), f"0{l}b")
-
-
-def hamming(a, b) -> int:
-    if isinstance(a, str):
-        a = hex_to_bitstr(a)
-        a = list(map(int, a))
-    if isinstance(b, str):
-        b = hex_to_bitstr(b)
-        b = list(map(int, b))
-
-    return np.bitwise_xor(a, b).sum()

--- a/videohash/videohash.py
+++ b/videohash/videohash.py
@@ -41,7 +41,7 @@ class VideoHash:
             raise ValueError(
                 f"Invalid hash length '{hash_length}'.\nMust be greater than or equal to 4 and a perfect square."
             )
-        self.hashlength = hash_length
+        self._hash_length = hash_length
 
         if not isinstance(video_path, Path):
             video_path = Path(video_path)
@@ -78,7 +78,7 @@ class VideoHash:
         for f in frames:
             f.close()
 
-        self.hash, self.hex = _calc_hash(self._collage, self.hashlength)
+        self.hash, self.hex = _calc_hash(self._collage, self._hash_length)
         self._collage.close()
 
     def __str__(self) -> str:
@@ -95,7 +95,7 @@ class VideoHash:
         :return: Developer's representation of the instance.
         """
 
-        return f"VideoHash(hash={self.hex}, hashlength={self.hashlength}"
+        return f"VideoHash(hash={self.hex}, hashlength={self._hash_length})"
 
     def __len__(self) -> int:
         """

--- a/videohash/videohash.py
+++ b/videohash/videohash.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-from subprocess import check_output
 from math import isqrt
 
 import imagehash

--- a/videohash/videohash.py
+++ b/videohash/videohash.py
@@ -29,11 +29,13 @@ class VideoHash:
         hash_length: int = 256,
         frame_count: int = 16,
         frame_size: int = 240,
+        maxerrors: int = 1,
         ffmpeg_threads: int = 4,
         ffmpeg_path: Path | str = "ffmpeg",
     ) -> None:
         """
         :param video_path: Absolute path of the input video file.
+        :param maxerrors: Maximum number of failed extracted frames (replaced by a black frame).
         :return: None
         """
         if hash_length < 4 or isqrt(hash_length) ** 2 != hash_length:
@@ -67,6 +69,7 @@ class VideoHash:
             frame_size=self._frame_size,
             ffmpeg_threads=ffmpeg_threads,
             ffmpeg_path=ffmpeg_path,
+            maxerrors=maxerrors,
         )
 
         self._collage = make_collage(


### PR DESCRIPTION
If only a single frame fails to extract replace it with a black frame and continue calculating the phash.

This might still allow for useful comparison, if the video/frames are otherwise similar enough.

`maxerrors` is configurable, default 1
This is probably not useful for frame sizes < 16 since a single black frame will ruin most of the phash (probably?)